### PR TITLE
chore: rename master to main and update CI to target develop only

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -11,7 +11,7 @@ Automated CI/CD pipelines for VTT Hardware Benchmarks.
 Automatically builds and publishes all benchmark container images to GitHub Container Registry.
 
 **Triggers:**
-- **Push to `master`**: Builds and pushes all images with `latest` tag
+- **Push to `develop`**: Builds and pushes all images with `latest` tag
 - **Pull Request**: Builds images for testing (doesn't push)
 - **Manual dispatch**: Build and push with custom version tag
 
@@ -38,7 +38,7 @@ ghcr.io/vvautosports/vtt-hw-benchmarks/vtt-benchmark-llama:latest
 ```bash
 # Via GitHub UI: Actions tab → Build and Push Containers → Run workflow
 # Or via gh CLI:
-gh workflow run build-and-push-containers.yml --ref master
+gh workflow run build-and-push-containers.yml --ref develop
 ```
 
 **Permissions:**
@@ -54,7 +54,7 @@ Runs linting on shell scripts and markdown files.
 
 **Triggers:**
 - **Push to any branch**
-- **Pull Request to `master`**
+- **Pull Request to `develop`**
 
 **What it does:**
 1. **Shellcheck**: Validates all bash scripts

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -2,12 +2,12 @@ name: Build and Push Containers
 
 on:
   push:
-    branches: [main, master]
+    branches: [develop]
     paths:
       - 'docker/**'
       - '.github/workflows/build-and-push-containers.yml'
   pull_request:
-    branches: [main, master]
+    branches: [develop]
     paths:
       - 'docker/**'
   workflow_dispatch:
@@ -88,7 +88,7 @@ jobs:
   notify-discord:
     needs: build-and-push
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
 
     steps:
       - name: Send Discord notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['**']
   pull_request:
-    branches: [main, master]
+    branches: [develop]
 
 jobs:
   shellcheck:

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ vtt-hw-benchmarks/
 
 ### Automated Container Builds
 
-Containers are automatically built and published to GitHub Container Registry on every push to `master`:
+Containers are automatically built and published to GitHub Container Registry on every push to `develop`:
 
 - **Registry:** `ghcr.io/vvautosports/vtt-hw-benchmarks`
 - **Images:** `7zip`, `stream`, `storage`, `llama`

--- a/docs/guides/HP-ZBOOK-DEPLOYMENT.md
+++ b/docs/guides/HP-ZBOOK-DEPLOYMENT.md
@@ -57,7 +57,7 @@ git clone https://github.com/vvautosports/vtt-hw-benchmarks.git
 cd vtt-hw-benchmarks
 
 # Option 2: Download ZIP
-# Download from: https://github.com/vvautosports/vtt-hw-benchmarks/archive/refs/heads/master.zip
+# Download from: https://github.com/vvautosports/vtt-hw-benchmarks/archive/refs/heads/main.zip
 # Extract to C:\vtt-hw-benchmarks
 ```
 

--- a/docs/guides/HP-ZBOOK-SETUP.md
+++ b/docs/guides/HP-ZBOOK-SETUP.md
@@ -18,8 +18,8 @@ powershell -ExecutionPolicy Bypass -File .\scripts\utils\Fetch-Setup-Instruction
 ```
 
 **Option 2: View in browser**
-- README: https://github.com/vvautosports/vtt-hw-benchmarks/blob/master/README.md
-- Setup Guide: https://github.com/vvautosports/vtt-hw-benchmarks/blob/master/docs/guides/HP-ZBOOK-SETUP.md
+- README: https://github.com/vvautosports/vtt-hw-benchmarks/blob/main/README.md
+- Setup Guide: https://github.com/vvautosports/vtt-hw-benchmarks/blob/main/docs/guides/HP-ZBOOK-SETUP.md
 
 **Option 3: Quick start script**
 ```powershell

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,7 +48,7 @@ echo $GITHUB_TOKEN | podman login ghcr.io -u USERNAME --password-stdin
 **Automated CI/CD:**
 
 The repository includes GitHub Actions workflows that automatically:
-- Build all 4 container images on push to `master`
+- Build all 4 container images on push to `develop`
 - Push images to GHCR with `latest` tag
 - Post notification to Discord (if webhook configured)
 - Run linting on all pull requests


### PR DESCRIPTION
## Summary
- GitHub branch `master` renamed to `main` (already done via API)
- `develop` set as new default branch (already done via API)
- CI workflows updated to trigger only on `develop` (main receives releases only via develop→main merges)
- Docs updated: README, .github/README, scripts/README, HP-ZBOOK guides
- Archive URLs updated from `master` to `main`

## Test Evidence — 2026-04-04
- [PASS] YAML validity — workflow files parse correctly (yamllint false-positive on GitHub Actions `${{ }}` syntax expected)
- [PASS] Manual review — all references to `master` replaced with `main` or `develop` as appropriate

## Test plan
- [ ] Verify CI workflow runs on next develop push
- [ ] Verify archive URLs resolve (github.com/.../archive/refs/heads/main.zip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)