### PR TITLE
fix(ci): resolve YAML syntax error blocking container build workflow

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -83,7 +83,8 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Image digest
-        run: echo "Built image with tags: ${{ steps.meta.outputs.tags }}"
+        run: |
+          echo "Built image with tags ${{ steps.meta.outputs.tags }}"
 
   notify-discord:
     needs: build-and-push


### PR DESCRIPTION
## Summary
- Fix unquoted colon inside run command string on line 86 of `build-and-push-containers.yml`
- Every run since this was introduced has failed with "workflow file issue" because YAML parsed the colon as a mapping separator

## Root Cause
```yaml
# Before (broken):
run: echo "Built image with tags: ${{ steps.meta.outputs.tags }}"

# After (fixed):
run: |
  echo "Built image with tags ${{ steps.meta.outputs.tags }}"
```

The colon inside the string needs to either be escaped by a block scalar (`|`) or the entire `run:` value must be wrapped in quotes. Block scalar is cleaner.

## Test Evidence — 2026-04-04
- [PASS] yamllint — 0 errors (syntax rule only)
- [PASS] python3 yaml.safe_load — parses cleanly
- [PASS] Manual review — only the Image digest step changed, all other steps unchanged

## Test plan
- [ ] After merge, verify build-and-push-containers workflow runs successfully
- [ ] Verify container images still build and push to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)